### PR TITLE
s3Uploadbucket as parameter

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -33,7 +33,8 @@ Parameters:
     Type: String
     Description: Base path mapping in CustomDomain
   S3UploadBucket:
-    Type: String
+    Type: 'AWS::SSM::Parameter::Value<String>'
+    Default: NVA/PublicationData
     Description: S3 Bucket to upload files to
 
 Resources:


### PR DESCRIPTION
The alternative would be the bucket to be defined in this stack. However, if we ever delete this stack retaining the bucket, we would not be able to connect to the bucket again, and we would have to create another bucket and create a process for copying the data from one bucket to other. Svenn's approach gives us the advantage of being able to delete the stack containing the logic without touching the data