### PR TITLE
removed body as required prepare parameter

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -295,7 +295,7 @@ components:
           example: f335ab02-35b3-4fda-9204-cd999e166ce0
         body:
           type: string
-          description: This parts content. Its not used, but needs to be present. Use "{}"
+          description: This parts content. Its provided by Uppy, but not used by the API.
           example: {}
         number:
           type: integer
@@ -304,7 +304,6 @@ components:
       required:
         - uploadId
         - key
-        - body
         - number
 
     AbortUploadRequestBody:

--- a/prepare-upload-part/src/main/java/no/unit/nva/fileupload/PrepareUploadPartHandler.java
+++ b/prepare-upload-part/src/main/java/no/unit/nva/fileupload/PrepareUploadPartHandler.java
@@ -86,7 +86,6 @@ public class PrepareUploadPartHandler extends ApiGatewayHandler<PrepareUploadPar
             requireNonNull(input.getKey());
             requireNonNull(input.getUploadId());
             requireNonNull(input.getNumber());
-            requireNonNull(input.getBody());
         } catch (Exception e) {
             logger.warn(e.getMessage());
             throw new InvalidInputException(e);


### PR DESCRIPTION
Is this a acceptable "middle ground" for the body issue? With this suggestion we dont throw if its missing, but if you supply it there is no functional difference